### PR TITLE
Allow a custom font style

### DIFF
--- a/ExampleApp/Base.lproj/Main.storyboard
+++ b/ExampleApp/Base.lproj/Main.storyboard
@@ -31,16 +31,25 @@
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Custom Style" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NFb-GH-lWO">
+                                <rect key="frame" x="249" y="163" width="103" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="fK4-F7-cIW" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" id="1bV-KJ-f52"/>
                             <constraint firstItem="fK4-F7-cIW" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="FDl-gC-0vd"/>
+                            <constraint firstItem="NFb-GH-lWO" firstAttribute="centerX" secondItem="pxr-ee-hGH" secondAttribute="centerX" id="Msj-yE-fb8"/>
+                            <constraint firstItem="NFb-GH-lWO" firstAttribute="top" secondItem="pxr-ee-hGH" secondAttribute="bottom" constant="75" id="fQG-hd-71f"/>
                             <constraint firstItem="pxr-ee-hGH" firstAttribute="centerX" secondItem="fK4-F7-cIW" secondAttribute="centerX" id="gPG-qO-ul7"/>
                             <constraint firstItem="pxr-ee-hGH" firstAttribute="top" secondItem="fK4-F7-cIW" secondAttribute="bottom" constant="17" id="jVD-2o-LdF"/>
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="customStyleLabel" destination="NFb-GH-lWO" id="1w0-Ep-70U"/>
                         <outlet property="heading" destination="fK4-F7-cIW" id="7eq-s8-glh"/>
                         <outlet property="tapme" destination="pxr-ee-hGH" id="iFL-Jc-GAb"/>
                     </connections>

--- a/ExampleApp/ViewController.swift
+++ b/ExampleApp/ViewController.swift
@@ -13,11 +13,23 @@ class ViewController: UIViewController {
 
     @IBOutlet weak var heading: UILabel!
     @IBOutlet weak var tapme: UIButton!
+    @IBOutlet weak var customStyleLabel: UILabel!
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        let style = "ReallyReallyBigFont"
+        Gliphy.DynamicFontRegistry.registry.addTextStyle(style, scaledFrom: UIFontTextStyleTitle1, byFactor: 1.5)
+        
         DynamicTypeManager.sharedInstance.watchLabel(heading, textStyle: UIFontTextStyleHeadline, fontName: "Georgia")
         DynamicTypeManager.sharedInstance.watchButton(tapme, textStyle: UIFontTextStyleBody, fontName: "Georgia")
+        
+
+    }
+    
+    override func viewWillAppear(animated: Bool) {
+        super.viewWillAppear(animated)
+        Gliphy.DynamicTypeManager.sharedInstance.watchLabel(customStyleLabel, textStyle: "ReallyReallyBigFont", fontName: "Helvetica")
     }
 }
 

--- a/Gliphy.podspec
+++ b/Gliphy.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Gliphy"
-  s.version      = "0.1.0"
+  s.version      = "0.2.0"
   s.summary      = "A Swift Library to help manage Dynamic Type"
 
   s.description  = <<-DESC

--- a/Gliphy.xcodeproj/project.pbxproj
+++ b/Gliphy.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A779B0881C8F67B50044996A /* DynamicFontRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = A779B0871C8F67B50044996A /* DynamicFontRegistry.swift */; };
+		A779B0891C8F67B50044996A /* DynamicFontRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = A779B0871C8F67B50044996A /* DynamicFontRegistry.swift */; };
+		A779B08A1C8F67B50044996A /* DynamicFontRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = A779B0871C8F67B50044996A /* DynamicFontRegistry.swift */; };
+		A779B08D1C8F69DA0044996A /* FontRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A779B08C1C8F69DA0044996A /* FontRegistryTests.swift */; };
 		A784B21D1C74171B004EB35B /* Gliphy.h in Headers */ = {isa = PBXBuildFile; fileRef = A784B21C1C74171B004EB35B /* Gliphy.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A784B2241C74171B004EB35B /* Gliphy.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A784B2191C74171B004EB35B /* Gliphy.framework */; };
 		A784B2291C74171B004EB35B /* GliphyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A784B2281C74171B004EB35B /* GliphyTests.swift */; };
@@ -34,6 +38,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		A779B0871C8F67B50044996A /* DynamicFontRegistry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DynamicFontRegistry.swift; sourceTree = "<group>"; };
+		A779B08C1C8F69DA0044996A /* FontRegistryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FontRegistryTests.swift; sourceTree = "<group>"; };
 		A784B2191C74171B004EB35B /* Gliphy.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Gliphy.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A784B21C1C74171B004EB35B /* Gliphy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Gliphy.h; sourceTree = "<group>"; };
 		A784B21E1C74171B004EB35B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -112,6 +118,7 @@
 			isa = PBXGroup;
 			children = (
 				A784B2281C74171B004EB35B /* GliphyTests.swift */,
+				A779B08C1C8F69DA0044996A /* FontRegistryTests.swift */,
 				A784B22A1C74171B004EB35B /* Info.plist */,
 			);
 			path = GliphyTests;
@@ -121,6 +128,7 @@
 			isa = PBXGroup;
 			children = (
 				A784B2341C7417B3004EB35B /* DynamicTypeManager.swift */,
+				A779B0871C8F67B50044996A /* DynamicFontRegistry.swift */,
 				A784B2371C741BED004EB35B /* DynamicTypeElement.swift */,
 				A784B23A1C741E84004EB35B /* NSMapTableExtensions.swift */,
 			);
@@ -281,6 +289,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A784B23B1C741E84004EB35B /* NSMapTableExtensions.swift in Sources */,
+				A779B0881C8F67B50044996A /* DynamicFontRegistry.swift in Sources */,
 				A784B2381C741BED004EB35B /* DynamicTypeElement.swift in Sources */,
 				A784B2351C7417B3004EB35B /* DynamicTypeManager.swift in Sources */,
 			);
@@ -290,8 +299,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A779B0891C8F67B50044996A /* DynamicFontRegistry.swift in Sources */,
 				A784B23C1C741E84004EB35B /* NSMapTableExtensions.swift in Sources */,
 				A784B2291C74171B004EB35B /* GliphyTests.swift in Sources */,
+				A779B08D1C8F69DA0044996A /* FontRegistryTests.swift in Sources */,
 				A784B2361C7417B3004EB35B /* DynamicTypeManager.swift in Sources */,
 				A784B2391C741BED004EB35B /* DynamicTypeElement.swift in Sources */,
 			);
@@ -303,6 +314,7 @@
 			files = (
 				A784B2471C743306004EB35B /* ViewController.swift in Sources */,
 				A784B2451C743306004EB35B /* AppDelegate.swift in Sources */,
+				A779B08A1C8F67B50044996A /* DynamicFontRegistry.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -523,6 +535,7 @@
 				A784B22F1C74171B004EB35B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		A784B2301C74171B004EB35B /* Build configuration list for PBXNativeTarget "GliphyTests" */ = {
 			isa = XCConfigurationList;
@@ -531,6 +544,7 @@
 				A784B2321C74171B004EB35B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		A784B2511C743306004EB35B /* Build configuration list for PBXNativeTarget "ExampleApp" */ = {
 			isa = XCConfigurationList;
@@ -539,6 +553,7 @@
 				A784B2531C743306004EB35B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/Gliphy/Core/DynamicFontRegistry.swift
+++ b/Gliphy/Core/DynamicFontRegistry.swift
@@ -1,0 +1,34 @@
+//
+//  DynamicFontRegistry.swift
+//  Gliphy
+//
+//  Created by Scott Williams on 3/8/16.
+//  Copyright © 2016 Tallwave. All rights reserved.
+//
+
+import UIKit
+
+struct ScaledFontDescriptor {
+    let originalTextStyle: String
+    let scaleAmount: Float
+}
+
+public class DynamicFontRegistry {
+    public static let registry = DynamicFontRegistry()
+    
+    private init() {}
+    
+    private var styleDictionary = [String: ScaledFontDescriptor]()
+    
+    public func addTextStyle(textStyle: String, scaledFrom originalTextStyle: String, byFactor scaleAmount: Float) {
+        styleDictionary[textStyle] = ScaledFontDescriptor(originalTextStyle: originalTextStyle, scaleAmount: scaleAmount)
+    }
+    
+    func scaledFontSizeForStyle(textStyle: String) -> CGFloat? {
+        if let descriptor = styleDictionary[textStyle] {
+            let baseFont = UIFont.preferredFontForTextStyle(descriptor.originalTextStyle)
+            return baseFont.pointSize * CGFloat(descriptor.scaleAmount)
+        }
+        return nil
+    }
+}

--- a/Gliphy/Core/DynamicFontRegistry.swift
+++ b/Gliphy/Core/DynamicFontRegistry.swift
@@ -8,22 +8,44 @@
 
 import UIKit
 
+/**
+ `ScaledFontDescriptor` describes how to scale a font with a specific text style.
+*/
 struct ScaledFontDescriptor {
     let originalTextStyle: String
     let scaleAmount: Float
 }
 
+/**
+ `DynamicFontRegistry` contains a list of custom font sizes that can be used with Dynamic Type. You can register a custom style that is a scaled version of an existing font style defined by iOS. When the custom font is retrieved it is scaled appropriately along with all the other fonts.
+*/
 public class DynamicFontRegistry {
+    
+    /**
+     The singleton instance of `DynamicFontRegistry`.
+    */
     public static let registry = DynamicFontRegistry()
     
     private init() {}
     
     private var styleDictionary = [String: ScaledFontDescriptor]()
     
+    /**
+     Registers a custom text style.
+     
+     - Parameter textStyle: The unique identifier for to be registered.
+     - Parameter scaledFrom: The built-in text style on which this is based.
+     - Parameter byFactor: The multiplier to scale the custom font by.
+    */
     public func addTextStyle(textStyle: String, scaledFrom originalTextStyle: String, byFactor scaleAmount: Float) {
         styleDictionary[textStyle] = ScaledFontDescriptor(originalTextStyle: originalTextStyle, scaleAmount: scaleAmount)
     }
     
+    /**
+     Retrieves a registered font size and scales it. If the text style was not registered, `nil` is returned.
+     
+     - Parameter textStyle: The identifier to look up.
+    */
     func scaledFontSizeForStyle(textStyle: String) -> CGFloat? {
         if let descriptor = styleDictionary[textStyle] {
             let baseFont = UIFont.preferredFontForTextStyle(descriptor.originalTextStyle)

--- a/Gliphy/Core/DynamicTypeManager.swift
+++ b/Gliphy/Core/DynamicTypeManager.swift
@@ -97,7 +97,7 @@ public class DynamicTypeManager {
     }
 
     /**
-     Looks up the `UIFont` with the `fontName` and the size defined by the `style`.
+     Looks up the `UIFont` with the `fontName` and the size defined by the `style`. Firsts checks the `DynamicFontRegistry` for a custom size, then the `preferredFontForTextStyle` for fonts.
      
      - Parameter style: The equivalent system font style to apply to the font.
      - Parameter fontName: The name of the non-system font.
@@ -105,6 +105,10 @@ public class DynamicTypeManager {
      - Returns: The font with the `fontName` and size defined by the preferred font with `style`. If the `fontName` is not a valid font on the device, the system font for the `style` is used.
     */
     func fontForTextStyle(style: String, fontName: String) -> UIFont {
+        if let customSize = DynamicFontRegistry.registry.scaledFontSizeForStyle(style) {
+            return UIFont(name: fontName, size: customSize)!
+        }
+        
         let systemFont = UIFont.preferredFontForTextStyle(style)
         guard let customFont = UIFont(name: fontName, size: systemFont.pointSize) else {
             return systemFont

--- a/Gliphy/Info.plist
+++ b/Gliphy/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1</string>
+	<string>0.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/GliphyTests/FontRegistryTests.swift
+++ b/GliphyTests/FontRegistryTests.swift
@@ -1,0 +1,26 @@
+//
+//  FontRegistryTests.swift
+//  Gliphy
+//
+//  Created by Scott Williams on 3/8/16.
+//  Copyright © 2016 Tallwave. All rights reserved.
+//
+
+import XCTest
+@testable import Gliphy
+
+class FontRegistryTests: XCTestCase {
+    
+    func testRetrieveSize() {
+        DynamicFontRegistry.registry.addTextStyle("ReallyBigFont", scaledFrom: UIFontTextStyleTitle1, byFactor: 1.2)
+        let result = DynamicFontRegistry.registry.scaledFontSizeForStyle("ReallyBigFont")
+        XCTAssertNotNil(result)
+        XCTAssertNotEqual(result, 12.0)
+    }
+    
+    func testNilRetrieval() {
+        let result = DynamicFontRegistry.registry.scaledFontSizeForStyle("DoesNotExist")
+        XCTAssertNil(result)
+    }
+    
+}


### PR DESCRIPTION
1. Register a custom font style in the `DynamicFontRegistry`.

``` swift
DynamicFontRegistry.registry.addTextStyle("SuperBigFont", scaledFrom: UIFontTextStyleTitle1, byFactor: 1.5)
```
1. Add your watchers on Views with the new style.

``` swift
DynamicTypeManager.sharedInstance.watchLabel(aLabel, textStyle: "SuperBigFont", fontName: "Helvetica")
```
